### PR TITLE
Eliminados métodos y propiedades que referencian a métodos de creación de turnos médicos.

### DIFF
--- a/HealthManager/Controllers/AdminController.cs
+++ b/HealthManager/Controllers/AdminController.cs
@@ -13,9 +13,7 @@ namespace HealthManager.Controllers
         {
             _dbcontext = context;
         }
-        public IActionResult AppointmentsManager()
         {
-            return View();
         }
 
         [HttpGet]

--- a/HealthManager/Controllers/AdminController.cs
+++ b/HealthManager/Controllers/AdminController.cs
@@ -7,13 +7,11 @@ namespace HealthManager.Controllers
 {
     public class AdminController : Controller
     {
-        private readonly IAppointments _appointmentsService;
         private readonly HealthManagerContext _dbcontext;
 
-        public AdminController(HealthManagerContext context, IAppointments appointmentsService)
+        public AdminController(HealthManagerContext context)
         {
             _dbcontext = context;
-            _appointmentsService = appointmentsService;
         }
         public IActionResult AppointmentsManager()
         {


### PR DESCRIPTION
- Debido a que la creación de turnos médicos se estableció como una tarea de fondo en la aplicación, ya no es necesario ejecutar el método de dicho método de manera manual, por lo que se decidió remover el uso de dicho método y las propiedades que referencian a la clase que aloja el método del controlador Admin.