### PR TITLE
Correcciones de errores y ajustes de filtros en turnos disponibles.

### DIFF
--- a/HealthManager/Controllers/AppointmentController.cs
+++ b/HealthManager/Controllers/AppointmentController.cs
@@ -103,15 +103,31 @@ namespace HealthManager.Controllers
 
         public async Task <JsonResult> GetAppointmentHours(string day, int doctorId)
         {
+            var now = DateTime.Now;
             var dateFromString = DateTime.Parse(day);
             var onlyDateFromDateTime = DateOnly.FromDateTime(dateFromString);
-            var currentHour = TimeOnly.FromDateTime(DateTime.Now);
-            var appointmentHours = await _dbcontext.Appointments
-                .Where(a => a.DoctorId == doctorId && a.AppointmentDate.Equals(onlyDateFromDateTime) &&a.AppointmentHour > currentHour && a.Status == "Available" )
-                .OrderBy(a => a.AppointmentHour)
+            var currentHour = TimeOnly.FromDateTime(DateTime.Now).AddHours(1);
+            var today = DateOnly.FromDateTime(now);
+
+            List<string> appointmentHours = new List<string>();
+
+            if (onlyDateFromDateTime.CompareTo(today) > 0)
+            {
+                 appointmentHours = await _dbcontext.Appointments
+                .Where(a => a.DoctorId == doctorId && a.AppointmentDate.Equals(onlyDateFromDateTime) && a.Status == "Available")
+                .OrderByDescending(a => a.AppointmentHour)
                 .Select(a => a.AppointmentHour.ToString("HH:mm"))
                 .ToListAsync();
-            return Json(appointmentHours);
+            }
+            else
+            {
+                 appointmentHours = await _dbcontext.Appointments
+                .Where(a => a.DoctorId == doctorId && a.AppointmentDate.Equals(onlyDateFromDateTime) && a.AppointmentHour >= currentHour && a.Status == "Available")
+                .OrderByDescending(a => a.AppointmentHour)
+                .Select(a => a.AppointmentHour.ToString("HH:mm"))
+                .ToListAsync();
+            }
+                return Json(appointmentHours);
         }
 
         public async Task<JsonResult> GetDoctorsBySpecialty(int specialty)

--- a/HealthManager/Controllers/AppointmentController.cs
+++ b/HealthManager/Controllers/AppointmentController.cs
@@ -87,11 +87,14 @@ namespace HealthManager.Controllers
         
         public async Task <JsonResult> GetAppointmentDates(int doctorId)
         {
+            var today = DateTime.Now;
             var currentMonth = DateTime.Now.Month;
-            var currentDay = DateTime.Now.Day;
-            var currentHour = TimeOnly.FromDateTime(DateTime.Now);
+            var currentDay = DateOnly.FromDateTime(today);
+            var currentHour = TimeOnly.FromDateTime(DateTime.Now).AddHours(1);
             var availableAppointments = await _dbcontext.Appointments
-                .Where(a => a.DoctorId == doctorId && a.AppointmentDate.Month == currentMonth && a.AppointmentDate.Day >= currentDay && a.AppointmentHour > currentHour && a.Status == "Available")
+                .Where(a => a.DoctorId == doctorId && ((a.AppointmentDate == currentDay && a.AppointmentHour >= currentHour) || a.AppointmentDate > currentDay) && a.Status == "Available")
+                .OrderByDescending(x => x.AppointmentDate)
+                .ThenByDescending(x => x.AppointmentHour)
                 .Select(a => a.AppointmentDate.ToString("dd/MM/yyyy"))
                 .Distinct()
                 .ToListAsync();

--- a/HealthManager/Controllers/AppointmentController.cs
+++ b/HealthManager/Controllers/AppointmentController.cs
@@ -57,7 +57,7 @@ namespace HealthManager.Controllers
                                 && x.Status == "Reserved")
                     .FirstOrDefaultAsync();
 
-                if (existingAppointment != null && existingAppointment.AppointmentDate.CompareTo(appointmentRequest.AppointmentDate) < 28)
+                if (existingAppointment != null && (existingAppointment.AppointmentDate.Day - appointmentRequest.AppointmentDate.Day) < 28)
                 {
                     ViewData.ModelState
                         .AddModelError("Appointment",

--- a/HealthManager/Controllers/PatientDashboardController.cs
+++ b/HealthManager/Controllers/PatientDashboardController.cs
@@ -37,14 +37,17 @@ namespace HealthManager.Controllers
              var patientAppointments = await _dbcontext.Appointments
                  .Where(p => p.PatientId == patientId && p.Status=="Reserved")
                  .ToListAsync();*/
-            DateOnly today = DateOnly.FromDateTime(DateTime.Now);
-            TimeOnly currentHour = TimeOnly.FromDateTime(DateTime.Now);
+            DateTime today = DateTime.Now;
+            DateOnly todayDate = DateOnly.FromDateTime(today);
+            TimeOnly todayhour = TimeOnly.FromDateTime(today);
             var userIdString = User.FindFirst("Id")?.Value;
             int.TryParse(userIdString, out int userIdInt);
             var patientAppointments = await _dbcontext.Appointments
-                 .Where(p => p.Status == "Reserved" && p.PatientId == userIdInt && p.AppointmentDate >= today && p.AppointmentHour > currentHour)
+                 .Where(p => p.Status == "Reserved" && p.PatientId == userIdInt && (p.AppointmentDate > todayDate || (p.AppointmentDate == todayDate && p.AppointmentHour > todayhour)))
                  .Include(a => a.Doctor)
                  .ThenInclude(d => d.SpecialtyNavigation)
+                 .OrderByDescending(x => x.AppointmentDate)
+                 .ThenByDescending(x => x.AppointmentHour)
                  .ToListAsync();
             List<PatientAppointmentsViewModel> appointmentsVm = patientAppointments.Select(x => new PatientAppointmentsViewModel
             {

--- a/HealthManager/HealthManager.csproj
+++ b/HealthManager/HealthManager.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>596195df-cb1a-41c4-b5bf-f375ab899d7c</UserSecretsId>
@@ -9,13 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HealthManager/Models/Admin.cs
+++ b/HealthManager/Models/Admin.cs
@@ -19,7 +19,7 @@ public partial class Admin
     [MinLength(12)]
     public string Password { get; set; } = null!;
 
-    public int PhoneNumber { get; set; }
+    public long PhoneNumber { get; set; }
 
     public string? Role { get; set; } = "Admin";
 }

--- a/HealthManager/Models/DTO/AppointmentViewModel.cs
+++ b/HealthManager/Models/DTO/AppointmentViewModel.cs
@@ -10,10 +10,7 @@ namespace HealthManager.Models.DTO
         [Required]
         public TimeOnly AppointmentHour { get; set; }
         [Required]
-        public string AppointmentTime { get; set; }
-        [Required]
-        [AllowedValues("Available", "Reserved")]
-        public string Status { get; set; } = null!;
+        public string Specialty { get; set; }
         [Required]
         public int PatientId { get; set; }
         [Required]

--- a/HealthManager/Models/DTO/PatientAppointmentsViewModel.cs
+++ b/HealthManager/Models/DTO/PatientAppointmentsViewModel.cs
@@ -1,0 +1,15 @@
+﻿namespace HealthManager.Models.DTO
+{
+    public class PatientAppointmentsViewModel
+    {
+        public Guid AppointmentId { get; set; }
+
+        public string DoctorName { get; set; }
+
+        public string DoctorSpecialty { get; set; }
+        
+        public DateOnly AppointmentDate { get; set; }
+        
+        public TimeOnly AppointmentHour { get; set; }
+    }
+}

--- a/HealthManager/Models/Doctor.cs
+++ b/HealthManager/Models/Doctor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace HealthManager.Models;
 


### PR DESCRIPTION
Proyecto:
- Se actualizó la versión de .NET del proyecto a la versión 9.0.
- Adicionalmente, se actualizaron las librerías y paquetes usados en el proyecto a la última versión disponible.

Backend:
- Se creó el viewmodel del turno médico del paciente para mostrar en la lista de turnos del paciente, archivo que faltaba en el PR anterior.
- Se eliminaron dependencias sin usar en el modelo de Doctor.
- Se eliminaron propiedades en desuso del viewmodel usado para la reserva de turnos.
- Se cambió el tipo de dato de la propiedad PhoneNumber del modelo Admin a long.
- Se hicieron ajustes en los filtros de reservas de turnos como los turnos próximos del paciente.
- En el caso de reservas de turnos, se hicieron ajustes para garantizar que el sistema traiga todos los turnos disponibles de un día en concreto si la fecha es posterior a la actual. Caso contrario, si la fecha es la misma que la fecha en la que se realiza la consulta, sólo traerá los turnos disponibles cuyo horario sea posterior al de ése momento sumado a un margen horario (temporalmente establecido a 1 hora).
- En el sistema de visualización de turnos próximos del paciente, se le mostrará una lista con los turnos posteriores de haberlos, y aquellos que tenga el mismo día de la consulta siempre y cuando no haya pasado el horario de la misma.
- En los últimos 2 sistemas, los turnos se ordenan en orden descendiente mediante fecha y hora.