### PR TITLE
Modificaciones en el sistema de creación de turnos médicos.

### DIFF
--- a/HealthManager/Models/DTO/DoctorDTO.cs
+++ b/HealthManager/Models/DTO/DoctorDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace HealthManager.Models.DTO
+{
+    public class DoctorDTO
+    {
+        public Doctor Doctor { get; set; } = null!;
+        public WorkingDay WorkingDay { get; set; } = null!;
+        public DoctorShift DoctorShift { get; set; } = null!;
+    }
+}

--- a/HealthManager/Services/Appointments/AppointmentsService.cs
+++ b/HealthManager/Services/Appointments/AppointmentsService.cs
@@ -84,6 +84,20 @@ namespace HealthManager.Services.Appointments
 
         }
 
+        public async Task<MethodResponse> CheckForExistingAppointments()
+        {
+            int currentMonth = DateTime.Now.Month;
+            var existingRegisters = await _context.Appointments.Where(a => a.AppointmentDate.Month == currentMonth).ToListAsync();
+            if (existingRegisters.Count > 0)
+            {
+                return new MethodResponse{Success = true, Message="There are registers corresponding to the present month in the database"};
+            }
+            else
+            {
+                return new MethodResponse { Success = false, Message="There are no registers corresponding to actual month in the database. It is recommended to create new appointments in the database"};
+            }
+        }
+
             using var transaction = await _context.Database.BeginTransactionAsync();
             try
             {

--- a/HealthManager/Services/Appointments/AppointmentsService.cs
+++ b/HealthManager/Services/Appointments/AppointmentsService.cs
@@ -98,6 +98,29 @@ namespace HealthManager.Services.Appointments
             }
         }
 
+        public async Task<MethodResponse> CheckAndCreateAppointments()
+        {
+            try
+            {
+                var existingRegisters = await CheckForExistingAppointments();
+
+                if (existingRegisters.Success.Equals(true))
+                {
+                    return new MethodResponse { Success = false, Message = "There are already appointments for this month" };
+                }
+                else
+                {
+                    await CreateAppointmentsForAllDoctors();
+                    return new MethodResponse { Success = true, Message = "Appointments were successfully created." };
+                }
+            }
+            catch (Exception error)
+            {
+                return new MethodResponse { Success = false, Message = error.ToString() };
+            }
+
+        }
+
             using var transaction = await _context.Database.BeginTransactionAsync();
             try
             {

--- a/HealthManager/Services/Appointments/IAppointments.cs
+++ b/HealthManager/Services/Appointments/IAppointments.cs
@@ -12,5 +12,7 @@ namespace HealthManager.Services.Appointments
 
         public Task<MethodResponse> CheckAndCreateAppointments();
 
+        public Task<MethodResponse> CreateDoctorAppointments(List<DoctorDTO> doctorList, int dayNumber);
+
     }
 }

--- a/HealthManager/Services/Appointments/IAppointments.cs
+++ b/HealthManager/Services/Appointments/IAppointments.cs
@@ -6,9 +6,9 @@ namespace HealthManager.Services.Appointments
 {
     public interface IAppointments
     {
-        public Task<MethodResponse> CheckForExistingRegisters();
+        public Task<MethodResponse> CheckForExistingAppointments();
 
-        public Task<MethodResponse> CreateAppointments();
+        public Task<MethodResponse> CreateAppointmentsForAllDoctors();
 
         public Task<MethodResponse> CheckAndCreateAppointments();
 


### PR DESCRIPTION
- Cambiados nombres de algunos métodos para hacerlos más descriptivos.
- Creado método reutilizable para crear los turnos médicos donde se pasó la lógica que originalmente estaba en el método CreateAppointments. En dicho método se crean turnos pertenecientes a un médico a partir de una fecha determinada del mes (sea el día donde se ejecuta el método o el principio de cada mes, como se supone se usará en la aplicación).
- Creado DTO para usar en el nuevo método reutilizable.
- Se implementó el uso del método creado donde se lo necesite