### PR TITLE
Añadida restricción de asistencia al momento de buscar un turno existente del paciente.

### DIFF
--- a/HealthManager/Controllers/AppointmentController.cs
+++ b/HealthManager/Controllers/AppointmentController.cs
@@ -61,7 +61,8 @@ namespace HealthManager.Controllers
                                 && (x.AppointmentDate.Month == appointmentRequest.AppointmentDate.Month 
                                     || x.AppointmentDate.Month == appointmentRequest.AppointmentDate.AddMonths(1).Month)
                                     && (x.AppointmentDate.Day > todayInt || (x.AppointmentDate == today && x.AppointmentHour > currentHour))
-                                && x.Status == "Reserved")
+                                && x.Status == "Reserved"
+                                && x.Attended == null)
                     .FirstOrDefaultAsync();
 
 


### PR DESCRIPTION
- Se añadió una restricción extra al momento de buscar un turno ya existente del paciente. También se buscará si hay un turno en el que la asistencia no fue registrada (o sea, según el sistema planteado, que todavía no haya asistido a la consulta o que se haya registrado como ausente en caso de que no haya asistido).